### PR TITLE
Update cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # CMake
 build/
+/unittest/benchmark
+/unittest/parser-spef-test
+/example/simple

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,13 +22,11 @@ message(STATUS "CMAKE_EXE_LINKER_FLAGS: " ${CMAKE_EXE_LINKER_FLAGS})
 
 
 # add the binary tree to the search path for include files
-include_directories(${PROJECT_SOURCE_DIR})
-include_directories(parser-spef)
-include_directories(doctest)
-
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE parser-spef)
 
 # -----------------------------------------------------------------------------
-# Example program 
+# Example program
 # -----------------------------------------------------------------------------
 message(STATUS "Building examples ...")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/example)
@@ -36,11 +34,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/example)
 message(STATUS "EXAMPLE_CXX_FLAGS: " ${EXAMPLE_CXX_FLAGS})
 message(STATUS "EXAMPLE_EXE_LINKER_FLAGS: " ${EXAMPLE_EXE_LINKER_FLAGS})
 
-add_executable(simple example/simple.cpp)
-
-#target_compile_options(simple PRIVATE "-pg")
-#target_link_libraries(simple stdc++fs "-pg")
-target_link_libraries(simple stdc++fs)
+add_executable(parser-spef-example example/simple.cpp)
+target_link_libraries(parser-spef-example stdc++fs ${PROJECT_NAME})
 
 # -----------------------------------------------------------------------------
 # Unittest
@@ -50,11 +45,13 @@ enable_testing()
 message(STATUS "Building unit tests ...")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/unittest)
 
-add_executable(parser-spef unittest/parser-spef.cpp)
-target_link_libraries(parser-spef stdc++fs)
+add_executable(parser-spef-test unittest/parser-spef.cpp)
+target_link_libraries(parser-spef-test stdc++fs ${PROJECT_NAME})
+target_include_directories(parser-spef-test PRIVATE doctest)
 
 add_executable(benchmark unittest/benchmark.cpp)
-target_link_libraries(benchmark stdc++fs)
+target_link_libraries(benchmark stdc++fs ${PROJECT_NAME})
+target_include_directories(benchmark PRIVATE doctest)
 
 
 add_test(HeaderFix ${PROJECT_SOURCE_DIR}/unittest/parser-spef -tc=Header.Fix)
@@ -65,4 +62,51 @@ add_test(Net ${PROJECT_SOURCE_DIR}/unittest/parser-spef -tc=Net)
 add_test(NameExpansion ${PROJECT_SOURCE_DIR}/unittest/parser-spef -tc=NAME_EXPANSION)
 add_test(Benchmark ${PROJECT_SOURCE_DIR}/unittest/benchmark)
 
+
+
+# INSTALL
+# Installation target
+install(
+  TARGETS Parser-SPEF
+  EXPORT Parser-SPEFTargets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/include/
+)
+
+# Export targets to install path
+# install(
+#   EXPORT Parser-SPEFTargets
+#   FILE Parser-SPEFTargets.cmake
+#   DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/Parser-SPEFTargets
+# )
+
+# Support use directly in build tree
+export(EXPORT Parser-SPEFTargets
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/Parser-SPEFTargets.cmake"
+)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/Parser-SPEFConfigVersion.cmake
+    VERSION 3.9
+    COMPATIBILITY ExactVersion
+    ARCH_INDEPENDENT
+)
+
+configure_package_config_file( Parser-SPEFConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/Parser-SPEFConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Parser-SPEF
+)
+
+export(EXPORT Parser-SPEFTargets
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/Parser-SPEF.cmake"
+  NAMESPACE Parser-SPEF::
+)
+
+install(
+    FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/Parser-SPEFConfig.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/Parser-SPEFConfigVersion.cmake
+    DESTINATION
+        ${CMAKE_INSTALL_LIBDIR}/cmake/Parser-SPEF
+)
 

--- a/Parser-SPEFConfig.cmake.in
+++ b/Parser-SPEFConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/Parser-SPEFTargets.cmake")
+
+check_required_components(Parser-SPEF)


### PR DESCRIPTION
Extends the cmake file for easier inclusion in other-projects. The PR supports both embedded:

```cmake
add_subdirectory(Parser-SPEF)
target_link_library(my_target PRIVATE Parser-SPEF)
```

or find_package

```cmake
find_package(Parser-SPEF 3.9 REQUIRED)
target_link_library(my_target PRIVATE Parser-SPEF::Parser-SPEF)
```